### PR TITLE
replaces all versions of nodejs to 10.x 

### DIFF
--- a/docs/permission-boundaries-advanced/verify.md
+++ b/docs/permission-boundaries-advanced/verify.md
@@ -152,7 +152,7 @@ zip lambdafunction.zip index.js
 ```
 * Create a Lambda function
 ```
-aws lambda create-function --function-name verifyfunction --runtime nodejs8.10 --role arn:aws:iam::<ACCOUNT_ID_FROM_OTHER_TEAM>:role/webadmins/NAME_OF_ROLE --handler index.handler --region us-east-1 --zip-file fileb://lambdafunction.zip --profile webadmins
+aws lambda create-function --function-name verifyfunction --runtime nodejs10.x --role arn:aws:iam::<ACCOUNT_ID_FROM_OTHER_TEAM>:role/webadmins/NAME_OF_ROLE --handler index.handler --region us-east-1 --zip-file fileb://lambdafunction.zip --profile webadmins
 ```
 * Invoke the Lambda function
 ```


### PR DESCRIPTION
Because nodejs8.10 is no longer a supported runtime

Resolves #5 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
