### PR TITLE
Changed AWSLambdaReadOnlyAccess  to AWSLambda_ReadOnlyAccess to reflect correct name for the policy

### DIFF
--- a/docs/permission-boundaries-advanced/build.md
+++ b/docs/permission-boundaries-advanced/build.md
@@ -136,9 +136,9 @@ First you will create an IAM role for the webadmins (initially this role will tr
 ```
 aws iam create-role --role-name webadmins --assume-role-policy-document file://trustpolicy.json
 ```
-* Attach the AWSLambdaReadOnlyAccess AWS Managed Policy to the role:
+* Attach the AWSLambda_ReadOnlyAccess AWS Managed Policy to the role:
 ```
-aws iam attach-role-policy --policy arn:aws:iam::aws:policy/AWSLambdaReadOnlyAccess --role-name webadmins
+aws iam attach-role-policy --policy arn:aws:iam::aws:policy/AWSLambda_ReadOnlyAccess --role-name webadmins
 ```
 
 
@@ -313,7 +313,7 @@ aws iam create-policy --policy-name webadminspermissionpolicy --policy-document 
 ```
 aws iam attach-role-policy --role-name webadmins --policy-arn arn:aws:iam::<ACCOUNT_ID>:policy/webadminspermissionpolicy
 ```
-When you are done the **webadmins** role should have these two policies attached: **webadminspermissionpolicy** & **AWSLambdaReadOnlyAccess**.
+When you are done the **webadmins** role should have these two policies attached: **webadminspermissionpolicy** & **AWSLambda_ReadOnlyAccess**.
 
 !!! question "Questions"
 

--- a/docs/permission-boundaries-advanced/verify.md
+++ b/docs/permission-boundaries-advanced/verify.md
@@ -196,7 +196,7 @@ Resources created in the **BUILD** phase
 * Detach the two policies from the webadmins role created in the **BUILD** phase:
 ```
 aws iam detach-role-policy --role-name webadmins --policy-arn arn:aws:iam::<ACCOUNT_ID>:policy/webadminspermissionpolicy
-aws iam detach-role-policy --role-name webadmins --policy-arn arn:aws:iam::aws:policy/AWSLambdaReadOnlyAccess 
+aws iam detach-role-policy --role-name webadmins --policy-arn arn:aws:iam::aws:policy/AWSLambda_ReadOnlyAccess 
 ```
 * Delete the webadmins role created in the **BUILD** phase:
 ```

--- a/docs/permission-boundaries/build.md
+++ b/docs/permission-boundaries/build.md
@@ -60,7 +60,7 @@ Build an IAM policy so that web admins can create customer managed policies, IAM
 * Browse to the [IAM console](https://console.aws.amazon.com/iam/home).
 * On the first screen you see in the IAM console (which should be the Dashboard) find the **IAM users sign-in link**. Copy that link because you will need the account ID in the URL for the policies and you will need the entire URL when you hand this account to another team for the **VERIFY** phase. 
 ![image1](./images/iam-dashboard.png)
-* Click **Users** on the left menu and create a new IAM user named **`webadmin`**. Check **AWS Management Console access** and then either autogenerate a password or set a custom password. Uncheck **Require password reset**. Attach the AWS managed policies **IAMReadOnlyAccess** & **AWSLambdaReadOnlyAccess** to the user.
+* Click **Users** on the left menu and create a new IAM user named **`webadmin`**. Check **AWS Management Console access** and then either autogenerate a password or set a custom password. Uncheck **Require password reset**. Attach the AWS managed policies **IAMReadOnlyAccess** & **AWSLambda_ReadOnlyAccess** to the user.
 ![image1](./images/create-iam-user.png)
 * Next click **Policies** on the left menu. Create a new IAM policy based on the hint below. Attach this policy to the **`webadmin`** IAM user you just created.
 
@@ -290,7 +290,7 @@ Note that the policy below contains two additional sections (the last two sectio
 ```
 
 * Name the new policy **`webadminpermissionpolicy`** and attach it to the webadmin user. Remove the earlier policy you added during the testing.
-* When you are done the **webadmin** user should have only three policies attached: webadminpermissionpolicy, IAMReadOnlyAccess & AWSLambdaReadOnlyAccess.
+* When you are done the **webadmin** user should have only three policies attached: webadminpermissionpolicy, IAMReadOnlyAccess & AWSLambda_ReadOnlyAccess.
 		
 * Again from the browser where you are logged into the console as the **webadmin**, verify the user can create a policy, create a role (attaching both a permission policy and permissions boundary to the role) and finally create a Lambda function into which you will pass that role. Keep in mind the resource restriction. 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes: Changed AWSLambdaReadOnlyAccess  to AWSLambda_ReadOnlyAccess to reflect correct name for the policy


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

The policy name was changed on March 1st, please see here for more information:
https://docs.aws.amazon.com/lambda/latest/dg/access-control-identity-based.html
