### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/docs/permission-boundaries-advanced/verify.md
+++ b/docs/permission-boundaries-advanced/verify.md
@@ -152,7 +152,7 @@ zip lambdafunction.zip index.js
 ```
 * Create a Lambda function
 ```
-aws lambda create-function --function-name verifyfunction --runtime nodejs10.x --role arn:aws:iam::<ACCOUNT_ID_FROM_OTHER_TEAM>:role/webadmins/NAME_OF_ROLE --handler index.handler --region us-east-1 --zip-file fileb://lambdafunction.zip --profile webadmins
+aws lambda create-function --function-name verifyfunction --runtime nodejs14.x --role arn:aws:iam::<ACCOUNT_ID_FROM_OTHER_TEAM>:role/webadmins/NAME_OF_ROLE --handler index.handler --region us-east-1 --zip-file fileb://lambdafunction.zip --profile webadmins
 ```
 * Invoke the Lambda function
 ```


### PR DESCRIPTION
CloudFormation templates in aws-identity-round-robin-workshop have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.